### PR TITLE
[CALCITE-5613] Assert for number of args for metadata methods

### DIFF
--- a/core/src/main/java/org/apache/calcite/rel/metadata/janino/CacheGeneratorUtil.java
+++ b/core/src/main/java/org/apache/calcite/rel/metadata/janino/CacheGeneratorUtil.java
@@ -209,6 +209,7 @@ class CacheGeneratorUtil {
 
       /** Returns e.g. ", ignoreNulls". */
       private StringBuilder safeArgList(StringBuilder buff, Method method) {
+        assert method.getParameterCount() >= 2 : "At least 2 metadata method parameters are required";
         // We ignore the first 2 arguments since they are included other ways.
         for (Ord<Class<?>> t : Ord.zip(method.getParameterTypes())
             .subList(2, method.getParameterCount())) {


### PR DESCRIPTION
Added an assert for the number of args for metadata methods at CacheGeneratorUtil.
Jira ticket - https://issues.apache.org/jira/browse/CALCITE-5613
